### PR TITLE
Fix complex macro

### DIFF
--- a/packages/scipy/patches/0004-make-int-return-values.patch
+++ b/packages/scipy/patches/0004-make-int-return-values.patch
@@ -185,9 +185,9 @@ index 5afc93b5d9..7ac5f80fb9 100644
  
  #include <stdlib.h>
  
++#undef complex
 +#include "f2c.h"
-+
-+
++#define complex singlecomplex
  /*
   * Support routines
   */


### PR DESCRIPTION
Try to fix f2c complex macro issue (https://github.com/pyodide/pyodide/pull/4925#issuecomment-2288824486)

The `complex` type is defined in f2c.h as:

```c
typedef struct { real r, i; } complex;
```

But it collides with the [complex macro in libc](https://github.com/emscripten-core/emscripten/blob/6bdc7e266e5a3e0aafda11392af81b8c1d9d43bc/system/lib/libc/musl/include/complex.h#L8):

```
#define complex _Complex
```

So this patch undefines macro before importing f2c.h. I am not sure if this is a right way to go... but it build anyways.